### PR TITLE
HTML encode devfs rules for edit box

### DIFF
--- a/conf/ext/thebrig/gui_addons.inc
+++ b/conf/ext/thebrig/gui_addons.inc
@@ -547,6 +547,8 @@ function html_optionsbox($ctrlname, $title, $value, $j_opt, $required = false, $
 	$ctrl->Render();
 }
 function html_brigdevfs_box($ctrlname, $title, $value, $desc,  $required = false, $readonly = false) {
+ 	foreach ($value as &$curString)
+          { $curString = htmlspecialchars($curString, ENT_QUOTES); }
 	$ctrl = new HTMLBrigdevfs($ctrlname, $title, $value, $desc);
 	$ctrl->SetRequired($required);
 	$ctrl->SetReadOnly($readonly);	


### PR DESCRIPTION
Hi noticed that entries from devfs rules from config.xml are not HTML encoded when creating the edit form.
Result is that rules rule with single quotes get corrupted (everything after the single quote is lost)

Happy to share back. 
Cheers